### PR TITLE
fix: corrected deployment nodeselector indentation

### DIFF
--- a/charts/typesense-kubernetes-operator/templates/deployment.yaml
+++ b/charts/typesense-kubernetes-operator/templates/deployment.yaml
@@ -33,5 +33,5 @@ spec:
             limits:
               memory: {{ .Values.resources.limits.memory }}
               cpu: {{ .Values.resources.limits.cpu }}
-          nodeSelector:
-            {{- toYaml .Values.nodeSelector | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 12 }}


### PR DESCRIPTION
During helm chart installation, I was getting following error:
```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "nodeSelector" in io.k8s.api.core.v1.Container
``` 
This indentation issue and this MR will fix it.